### PR TITLE
OTAB-3: The disk size is now set correctly

### DIFF
--- a/examples/tableau-infrastructure-modules/tableau-deployment/02-ha-tableau/staging/blue/terraform.tfvars
+++ b/examples/tableau-infrastructure-modules/tableau-deployment/02-ha-tableau/staging/blue/terraform.tfvars
@@ -11,7 +11,7 @@
 
 suffix = "blue"
 data_volume_size = "100"
-root_disk_size = "100"
+root_disk_size = "150"
 instance_type = "m5.4xlarge"
 common_tags = {
   Application = "Tableau Server"

--- a/examples/tableau-infrastructure-modules/tableau-deployment/02-ha-tableau/staging/green/terraform.tfvars
+++ b/examples/tableau-infrastructure-modules/tableau-deployment/02-ha-tableau/staging/green/terraform.tfvars
@@ -11,7 +11,7 @@
 
 suffix = "green"
 data_volume_size = "100"
-root_disk_size = "100"
+root_disk_size = "150"
 instance_type = "m5.4xlarge"
 common_tags = {
   Application = "Tableau Server"


### PR DESCRIPTION
The example disk size was originally set to 100GB, which is not enough for the built AMIs