### PR TITLE
OSO-23: DNS and ALB may now be internal.

### DIFF
--- a/examples/tableau-infrastructure-modules/tableau-deployment/02-ha-tableau/main.tf
+++ b/examples/tableau-infrastructure-modules/tableau-deployment/02-ha-tableau/main.tf
@@ -16,4 +16,5 @@ module "tableau_server" {
   root_disk_size          = var.root_disk_size
   data_volume_size        = var.data_volume_size
   vpc_name                = var.vpc_name
+  alb_internal            = var.alb_internal
 }

--- a/examples/tableau-infrastructure-modules/tableau-deployment/02-ha-tableau/variables.tf
+++ b/examples/tableau-infrastructure-modules/tableau-deployment/02-ha-tableau/variables.tf
@@ -93,3 +93,9 @@ variable vpc_name {
   description = "Name of the VPC we will deploy into"
   type        = string
 }
+
+variable alb_internal {
+  description = "Force load-balancers to be internal"
+  type        = string
+  default     = false
+}

--- a/examples/tableau-infrastructure-modules/tableau-deployment/03-dns-selector/main.tf
+++ b/examples/tableau-infrastructure-modules/tableau-deployment/03-dns-selector/main.tf
@@ -1,7 +1,8 @@
 module "dns_selector" {
-  source          = "git::ssh://git@github.com/osodevops/aws-terraform-module-tableau.git//modules/dns-selector"
-  environment     = var.environment
-  public_dns_zone = var.public_dns_zone
-  suffix          = var.suffix
-  common_tags     = var.common_tags
+  source           = "git::ssh://git@github.com/osodevops/aws-terraform-module-tableau.git//modules/dns-selector"
+  environment      = var.environment
+  dns_zone         = var.dns_zone
+  suffix           = var.suffix
+  common_tags      = var.common_tags
+  is_private_zone  = var.is_private_zone
 }

--- a/examples/tableau-infrastructure-modules/tableau-deployment/03-dns-selector/staging/terraform.tfvars
+++ b/examples/tableau-infrastructure-modules/tableau-deployment/03-dns-selector/staging/terraform.tfvars
@@ -11,3 +11,4 @@ common_tags = {
 
 # Select "blue" or "green" to flip the DNS to the appropriate Tableau installation
 suffix = "blue"
+is_private_zone = false

--- a/examples/tableau-infrastructure-modules/tableau-deployment/03-dns-selector/variables.tf
+++ b/examples/tableau-infrastructure-modules/tableau-deployment/03-dns-selector/variables.tf
@@ -19,12 +19,13 @@ variable suffix {
   default     = "green"
 }
 
-variable "public_dns_zone" {
+variable "dns_zone" {
   type    = string
   default = ""
 }
 
-variable "assume_role" {
-  description = "Name of role in peer account to assume"
-  default     = "Terraforming-Local-Admin"
+variable "is_private_zone" {
+  description = "Specify if your hosted zone is public or private"
+  type        = string
+  default     = false
 }


### PR DESCRIPTION
Using a new feature.

The ALBs may optionally be internal, with corresponding DNS
Parameters supported by the updated version of the tableau module.
